### PR TITLE
reconnect fix

### DIFF
--- a/audience.go
+++ b/audience.go
@@ -10,15 +10,12 @@ import (
 )
 
 func (s *Snitch) addAudience(ctx context.Context, aud *protos.Audience) {
-	// Don't need to add twice
-	if s.seenAudience(ctx, aud) {
-		return
-	}
-
 	s.audiencesMtx.Lock()
+
 	if s.audiences == nil {
 		s.audiences = make(map[string]struct{})
 	}
+
 	s.audiences[audToStr(aud)] = struct{}{}
 	s.audiencesMtx.Unlock()
 
@@ -28,18 +25,6 @@ func (s *Snitch) addAudience(ctx context.Context, aud *protos.Audience) {
 			s.config.Logger.Errorf("failed to add audience: %s", err)
 		}
 	}()
-}
-
-func (s *Snitch) seenAudience(_ context.Context, aud *protos.Audience) bool {
-	s.audiencesMtx.RLock()
-	defer s.audiencesMtx.RUnlock()
-
-	if s.audiences == nil {
-		return false
-	}
-
-	_, ok := s.audiences[audToStr(aud)]
-	return ok
 }
 
 func audToStr(aud *protos.Audience) string {

--- a/audience.go
+++ b/audience.go
@@ -10,12 +10,12 @@ import (
 )
 
 func (s *Snitch) addAudience(ctx context.Context, aud *protos.Audience) {
-	s.audiencesMtx.Lock()
-
 	// Don't need to add twice
 	if s.seenAudience(ctx, aud) {
 		return
 	}
+
+	s.audiencesMtx.Lock()
 
 	if s.audiences == nil {
 		s.audiences = make(map[string]struct{})

--- a/audience.go
+++ b/audience.go
@@ -12,6 +12,11 @@ import (
 func (s *Snitch) addAudience(ctx context.Context, aud *protos.Audience) {
 	s.audiencesMtx.Lock()
 
+	// Don't need to add twice
+	if s.seenAudience(ctx, aud) {
+		return
+	}
+
 	if s.audiences == nil {
 		s.audiences = make(map[string]struct{})
 	}
@@ -25,6 +30,42 @@ func (s *Snitch) addAudience(ctx context.Context, aud *protos.Audience) {
 			s.config.Logger.Errorf("failed to add audience: %s", err)
 		}
 	}()
+}
+
+// addAudiences is used for RE-adding audiences that may have timed out after
+// a server reconnect. The method will re-add all known audiences to snitch-server
+// via internal gRPC NewAudience() endpoint. This is a non-blocking method.
+func (s *Snitch) addAudiences(ctx context.Context) {
+	s.audiencesMtx.RLock()
+	defer s.audiencesMtx.RUnlock()
+
+	for audStr, _ := range s.audiences {
+		aud := strToAud(audStr)
+
+		if aud == nil {
+			s.config.Logger.Errorf("unexpected strToAud resulted in nil audience (audStr: %s)", audStr)
+			continue
+		}
+
+		// Run as goroutine to avoid blocking processing
+		go func() {
+			if err := s.serverClient.NewAudience(ctx, aud, s.sessionID); err != nil {
+				s.config.Logger.Errorf("failed to add audience: %s", err)
+			}
+		}()
+	}
+}
+
+func (s *Snitch) seenAudience(_ context.Context, aud *protos.Audience) bool {
+	s.audiencesMtx.RLock()
+	defer s.audiencesMtx.RUnlock()
+
+	if s.audiences == nil {
+		return false
+	}
+
+	_, ok := s.audiences[audToStr(aud)]
+	return ok
 }
 
 func audToStr(aud *protos.Audience) string {

--- a/audience_test.go
+++ b/audience_test.go
@@ -62,36 +62,6 @@ func TestStrToAud(t *testing.T) {
 	})
 }
 
-func TestSeenAudience(t *testing.T) {
-	ctx := context.Background()
-
-	s := &Snitch{
-		audiencesMtx: &sync.RWMutex{},
-		audiences:    map[string]struct{}{},
-	}
-
-	aud := &protos.Audience{
-		ServiceName:   "mysvc1",
-		ComponentName: "kafka",
-		OperationType: protos.OperationType_OPERATION_TYPE_PRODUCER,
-		OperationName: "mytopic",
-	}
-
-	t.Run("empty audiences", func(t *testing.T) {
-		if s.seenAudience(ctx, aud) != false {
-			t.Error("expected false")
-		}
-	})
-
-	t.Run("audience seen", func(t *testing.T) {
-		s.audiences[audToStr(aud)] = struct{}{}
-
-		if s.seenAudience(ctx, aud) != true {
-			t.Error("expected true")
-		}
-	})
-}
-
 func TestAddAudience(t *testing.T) {
 	ctx := context.Background()
 

--- a/register.go
+++ b/register.go
@@ -5,7 +5,6 @@ import (
 	"runtime"
 	"strings"
 	"time"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/relistan/go-director"
@@ -165,32 +164,6 @@ func (s *Snitch) register(looper director.Looper) error {
 	})
 
 	return nil
-}
-
-// addAudiences is used for RE-adding audiences that may have timed out after
-// a server reconnect. The method will re-add all known audiences to snitch-server
-// via internal gRPC NewAudience() endpoint. This is a non-blocking method.
-func (s *Snitch) addAudiences(ctx context.Context) {
-	fmt.Println("re-adding audiences!!!")
-
-	s.audiencesMtx.RLock()
-	defer s.audiencesMtx.RUnlock()
-
-	for audStr, _ := range s.audiences {
-		 aud := strToAud(audStr)
-
-		 if aud == nil {
-			 s.config.Logger.Errorf("unexpected strToAud resulted in nil audience (audStr: %s)", audStr)
-			 continue
-		 }
-
-		// Run as goroutine to avoid blocking processing
-		go func() {
-			if err := s.serverClient.NewAudience(ctx, aud, s.sessionID); err != nil {
-				s.config.Logger.Errorf("failed to add audience: %s", err)
-			}
-		}()
-	}
 }
 
 func (s *Snitch) attachPipeline(_ context.Context, cmd *protos.Command) error {

--- a/snitch.go
+++ b/snitch.go
@@ -436,6 +436,7 @@ func (s *Snitch) Process(ctx context.Context, req *ProcessRequest) (*ProcessResp
 	counterBytes := types.ConsumeBytes
 	rateBytes := types.ConsumeBytesRate
 	rateProcessed := types.ConsumeProcessedRate
+
 	if req.OperationType == OperationTypeProducer {
 		counterError = types.ProduceErrorCount
 		counterProcessed = types.ProduceProcessedCount


### PR DESCRIPTION
@blinktag I have tested both of these fixes manually but did not add tests for `addAudiences()` because I did not know how to easily fake "client registers, then disconnects, then reconnects and causes `addAudiences()` to be ran". If you can easily figure it out - go for it :)

Fixes:

1. Needed to reset `stream` when stream recv got an error
- was only resetting it under one condition. This would mean that snitch-go-client would not be able to reconnect to `snitch-server` if the server had a graceful shutdown (ie. `docker stop ...`).

2. Needed to re-add audiences upon reconnect. If we do not do this, then snitch server will NOT know that there is an active client connected to it. It also means that `DetachPipeline` won't work with a reconnected snitch-go-client (because `DetachPipeline()` gRPC handler determines session ids by looking through `snitch_live` bucket, which without this fix, there would be no entry for the audiences this client has announced).