### PR TITLE
Dselans/handle kv commands

### DIFF
--- a/kv/kv.go
+++ b/kv/kv.go
@@ -23,6 +23,10 @@ type IKV interface {
 	// was overwritten
 	Set(key string, value string) bool
 
+	// Delete will delete a key from the KV store; return bool indicates if
+	// key existed before deletion
+	Delete(key string) bool
+
 	// Exists checks if a key exists in the KV store
 	Exists(key string) bool
 
@@ -76,6 +80,21 @@ func (k *KV) Set(key string, value string) bool {
 
 	k.kvs[key] = value
 	return false
+}
+
+func (k *KV) Delete(key string) bool {
+	k.kvsMtx.Lock()
+	defer k.kvsMtx.Unlock()
+
+	exists := false
+
+	if _, ok := k.kvs[key]; ok {
+		exists = true
+	}
+
+	delete(k.kvs, key)
+
+	return exists
 }
 
 func (k *KV) Exists(key string) bool {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -188,7 +188,7 @@ func (m *Metrics) getCounters() map[string]*counter {
 }
 
 func (m *Metrics) incr(_ context.Context, entry *types.CounterEntry) error {
-	// No need to validate - no way to reach here without validation
+	// No need to validate - no way to reach here without validate
 	c, ok := m.getCounter(entry)
 	if ok {
 		c.incr(entry)

--- a/register.go
+++ b/register.go
@@ -2,14 +2,18 @@ package snitch
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/relistan/go-director"
+	"github.com/streamdal/snitch-protos/build/go/protos/shared"
 
 	"github.com/streamdal/snitch-protos/build/go/protos"
+
+	"github.com/streamdal/snitch-go-client/validate"
 )
 
 func (s *Snitch) register(looper director.Looper) error {
@@ -115,53 +119,113 @@ func (s *Snitch) register(looper director.Looper) error {
 			return nil
 		}
 
-		if attach := cmd.GetAttachPipeline(); attach != nil {
-			s.config.Logger.Debugf("Received attach pipeline command: %s", attach.Pipeline.Id)
-			if err := s.attachPipeline(context.Background(), cmd); err != nil {
-				s.config.Logger.Errorf("Failed to attach pipeline: %s", err)
+		// Reset error just in case
+		err = nil
+
+		switch cmd.Command.(type) {
+		case *protos.Command_Kv:
+			s.config.Logger.Debug("Received kv command")
+			err = s.handleKVCommand(context.Background(), cmd.GetKv())
+		case *protos.Command_AttachPipeline:
+			s.config.Logger.Debug("Received attach pipeline command")
+			err = s.attachPipeline(context.Background(), cmd)
+		case *protos.Command_DetachPipeline:
+			s.config.Logger.Debug("Received detach pipeline command")
+			err = s.detachPipeline(context.Background(), cmd)
+		case *protos.Command_PausePipeline:
+			s.config.Logger.Debug("Received pause pipeline command")
+			err = s.pausePipeline(context.Background(), cmd)
+		case *protos.Command_ResumePipeline:
+			s.config.Logger.Debug("Received resume pipeline command")
+			err = s.resumePipeline(context.Background(), cmd)
+		case *protos.Command_Tail:
+			tail := cmd.GetTail()
+
+			if tail == nil {
+				s.config.Logger.Errorf("Received tail command with nil tail; full cmd: %+v", cmd)
 				return nil
 			}
-		} else if detach := cmd.GetDetachPipeline(); detach != nil {
-			s.config.Logger.Debugf("Received detach pipeline command: %s", detach.PipelineId)
-			if err := s.detachPipeline(context.Background(), cmd); err != nil {
-				s.config.Logger.Errorf("Failed to detach pipeline: %s", err)
+
+			if tail.GetRequest() == nil {
+				s.config.Logger.Errorf("Received tail command with nil Request; full cmd: %+v", cmd)
 				return nil
 			}
-		} else if pause := cmd.GetPausePipeline(); pause != nil {
-			s.config.Logger.Debugf("Received pause pipeline command: %s", pause.PipelineId)
-			if err := s.pausePipeline(context.Background(), cmd); err != nil {
-				s.config.Logger.Errorf("Failed to pause pipeline: %s", err)
-				return nil
-			}
-		} else if resume := cmd.GetResumePipeline(); resume != nil {
-			s.config.Logger.Debugf("Received resume pipeline command: %s", resume.PipelineId)
-			if err := s.resumePipeline(context.Background(), cmd); err != nil {
-				s.config.Logger.Errorf("Failed to resume pipeline: %s", err)
-				return nil
-			}
-		} else if tail := cmd.GetTail(); tail != nil {
-			switch tail.GetRequest().Type {
+
+			switch cmd.GetTail().GetRequest().Type {
 			case protos.TailRequestType_TAIL_REQUEST_TYPE_START:
 				s.config.Logger.Debugf("Received start tail command for pipeline '%s'", tail.GetRequest().PipelineId)
-				if err := s.tailPipeline(context.Background(), cmd); err != nil {
-					s.config.Logger.Errorf("Failed to tail pipeline: %s", err)
-					return nil
-				}
+				err = s.tailPipeline(context.Background(), cmd)
 			case protos.TailRequestType_TAIL_REQUEST_TYPE_STOP:
 				s.config.Logger.Debugf("Received stop tail command for pipeline '%s'", tail.GetRequest().PipelineId)
-				if err := s.stopTailPipeline(context.Background(), cmd); err != nil {
-					s.config.Logger.Errorf("Failed to stop tail pipeline: %s", err)
-					return nil
-				}
+				err = s.stopTailPipeline(context.Background(), cmd)
 			default:
 				s.config.Logger.Errorf("Unknown tail command type: %s", tail.GetRequest().Type)
 				return nil
 			}
+		default:
+			err = fmt.Errorf("unknown command type: %+v", cmd.Command)
+		}
 
+		if err != nil {
+			s.config.Logger.Errorf("Failed to handle command: %s", cmd.Command)
+			return nil
 		}
 
 		return nil
 	})
+
+	return nil
+}
+
+// addAudiences is used for RE-adding audiences that may have timed out after
+// a server reconnect. The method will re-add all known audiences to snitch-server
+// via internal gRPC NewAudience() endpoint. This is a non-blocking method.
+func (s *Snitch) addAudiences(ctx context.Context) {
+	fmt.Println("re-adding audiences!!!")
+
+	s.audiencesMtx.RLock()
+	defer s.audiencesMtx.RUnlock()
+
+	for audStr, _ := range s.audiences {
+		aud := strToAud(audStr)
+
+		if aud == nil {
+			s.config.Logger.Errorf("unexpected strToAud resulted in nil audience (audStr: %s)", audStr)
+			continue
+		}
+
+		// Run as goroutine to avoid blocking processing
+		go func() {
+			if err := s.serverClient.NewAudience(ctx, aud, s.sessionID); err != nil {
+				s.config.Logger.Errorf("failed to add audience: %s", err)
+			}
+		}()
+	}
+}
+
+func (s *Snitch) handleKVCommand(_ context.Context, kv *protos.KVCommand) error {
+	if err := validate.KVCommand(kv); err != nil {
+		return errors.Wrap(err, "failed to validate kv command")
+	}
+
+	for _, i := range kv.Instructions {
+		if err := validate.KVInstruction(i); err != nil {
+			s.config.Logger.Debugf("KV instruction '%s' failed validate: %s (skipping)", i.Action, err)
+			continue
+		}
+
+		switch i.Action {
+		case shared.KVAction_KV_ACTION_CREATE | shared.KVAction_KV_ACTION_UPDATE:
+			s.kv.Set(i.Object.Key, string(i.Object.Value))
+		case shared.KVAction_KV_ACTION_DELETE:
+			s.kv.Delete(i.Object.Key)
+		case shared.KVAction_KV_ACTION_DELETE_ALL:
+			s.kv.Purge()
+		default:
+			s.config.Logger.Debugf("invalid KV action '%s' - skipping", i.Action)
+			continue
+		}
+	}
 
 	return nil
 }

--- a/register.go
+++ b/register.go
@@ -181,32 +181,6 @@ func (s *Snitch) register(looper director.Looper) error {
 	return nil
 }
 
-// addAudiences is used for RE-adding audiences that may have timed out after
-// a server reconnect. The method will re-add all known audiences to snitch-server
-// via internal gRPC NewAudience() endpoint. This is a non-blocking method.
-func (s *Snitch) addAudiences(ctx context.Context) {
-	fmt.Println("re-adding audiences!!!")
-
-	s.audiencesMtx.RLock()
-	defer s.audiencesMtx.RUnlock()
-
-	for audStr, _ := range s.audiences {
-		aud := strToAud(audStr)
-
-		if aud == nil {
-			s.config.Logger.Errorf("unexpected strToAud resulted in nil audience (audStr: %s)", audStr)
-			continue
-		}
-
-		// Run as goroutine to avoid blocking processing
-		go func() {
-			if err := s.serverClient.NewAudience(ctx, aud, s.sessionID); err != nil {
-				s.config.Logger.Errorf("failed to add audience: %s", err)
-			}
-		}()
-	}
-}
-
 func (s *Snitch) handleKVCommand(_ context.Context, kv *protos.KVCommand) error {
 	if err := validate.KVCommand(kv); err != nil {
 		return errors.Wrap(err, "failed to validate kv command")

--- a/tail.go
+++ b/tail.go
@@ -15,6 +15,7 @@ import (
 	"github.com/streamdal/snitch-go-client/logger"
 	"github.com/streamdal/snitch-go-client/metrics"
 	"github.com/streamdal/snitch-go-client/server"
+	"github.com/streamdal/snitch-go-client/types"
 	"github.com/streamdal/snitch-go-client/validate"
 )
 

--- a/tail.go
+++ b/tail.go
@@ -15,8 +15,7 @@ import (
 	"github.com/streamdal/snitch-go-client/logger"
 	"github.com/streamdal/snitch-go-client/metrics"
 	"github.com/streamdal/snitch-go-client/server"
-	"github.com/streamdal/snitch-go-client/types"
-	"github.com/streamdal/snitch-go-client/validation"
+	"github.com/streamdal/snitch-go-client/validate"
 )
 
 const (
@@ -146,7 +145,7 @@ func (t *Tail) startWorker(looper director.Looper, stream protos.Internal_SendTa
 }
 
 func (s *Snitch) tailPipeline(_ context.Context, cmd *protos.Command) error {
-	if err := validation.ValidateTailRequestStartCommand(cmd); err != nil {
+	if err := validate.TailRequestStartCommand(cmd); err != nil {
 		return errors.Wrap(err, "invalid tail command")
 	}
 
@@ -189,7 +188,7 @@ func (s *Snitch) tailPipeline(_ context.Context, cmd *protos.Command) error {
 }
 
 func (s *Snitch) stopTailPipeline(_ context.Context, cmd *protos.Command) error {
-	if err := validation.ValidateTailRequestStopCommand(cmd); err != nil {
+	if err := validate.TailRequestStopCommand(cmd); err != nil {
 		return errors.Wrap(err, "invalid tail request stop command")
 	}
 

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -1,7 +1,8 @@
-package validation
+package validate
 
 import (
 	"github.com/pkg/errors"
+	"github.com/streamdal/snitch-protos/build/go/protos/shared"
 
 	"github.com/streamdal/snitch-protos/build/go/protos"
 )
@@ -22,7 +23,7 @@ func ErrUnsetEnum(field string) error {
 	return errors.Errorf("enum '%s' cannot be unset", field)
 }
 
-func ValidateAudience(aud *protos.Audience) error {
+func Audience(aud *protos.Audience) error {
 	if aud == nil {
 		return ErrNilInput
 	}
@@ -46,7 +47,23 @@ func ValidateAudience(aud *protos.Audience) error {
 	return nil
 }
 
-func ValidateTailRequestStartCommand(cmd *protos.Command) error {
+func KVInstruction(i *protos.KVInstruction) error {
+	if i == nil {
+		return errors.New("KVInstruction cannot be nil")
+	}
+
+	if i.Action == shared.KVAction_KV_ACTION_UNSET {
+		return errors.New("KVAction cannot be UNSET")
+	}
+
+	if i.Object == nil {
+		return errors.New("KVInstruction.Object cannot be nil")
+	}
+
+	return nil
+}
+
+func TailRequestStartCommand(cmd *protos.Command) error {
 	if cmd == nil {
 		return ErrNilInput
 	}
@@ -65,14 +82,14 @@ func ValidateTailRequestStartCommand(cmd *protos.Command) error {
 		return ErrEmptyField("pipeline_id")
 	}
 
-	if err := ValidateAudience(cmd.Audience); err != nil {
+	if err := Audience(cmd.Audience); err != nil {
 		return errors.Wrap(err, "invalid audience")
 	}
 
 	return nil
 }
 
-func ValidateTailRequestStopCommand(cmd *protos.Command) error {
+func TailRequestStopCommand(cmd *protos.Command) error {
 	if cmd == nil {
 		return ErrNilInput
 	}
@@ -89,6 +106,14 @@ func ValidateTailRequestStopCommand(cmd *protos.Command) error {
 
 	if req.Id == "" {
 		return ErrEmptyField("id")
+	}
+
+	return nil
+}
+
+func KVCommand(kv *protos.KVCommand) error {
+	if kv == nil {
+		return ErrNilInput
 	}
 
 	return nil


### PR DESCRIPTION
@blinktag A few changes in here.

1. I reorganized & standardized a few things (like `validation` -> `validate` and removed the "Validate" in the validation func names to avoid stutter). I also cleaned up the big if/else in `Process()`. If there was a reason you did the if/else - I'll change back.
2. I added some more validations to avoid panics - `cmd` could not have an `Audience` (like a KVCommand), so accessing cmd.Audience would panic. 
3. I had forgotten to expose "delete" - woops. Added that. 
4. Added a bit more logging to help debug

Turns out I didn't write KV command handler bits in the client.

This has been tested as working - snitch-server sends cmds on startup and whenever `snitch-server` receives KV instructions over its HTTP API.

This PR goes together with the snitch-server PR: https://github.com/streamdal/snitch-server/pull/40