### PR TITLE
Dselans/catch err on startup

### DIFF
--- a/register.go
+++ b/register.go
@@ -23,7 +23,7 @@ func (s *Snitch) register(looper director.Looper) error {
 		ClientInfo: &protos.ClientInfo{
 			ClientType:     protos.ClientType(s.config.ClientType),
 			LibraryName:    "snitch-go-client",
-			LibraryVersion: "0.0.40",
+			LibraryVersion: "0.0.40", // TODO: Have CI bump this on release
 			Language:       "go",
 			Arch:           runtime.GOARCH,
 			Os:             runtime.GOOS,
@@ -36,12 +36,18 @@ func (s *Snitch) register(looper director.Looper) error {
 		req.Audiences = append(req.Audiences, aud.ToProto())
 	}
 
-	var stream protos.Internal_RegisterClient
-	var err error
-	var quit bool
+	var (
+		stream protos.Internal_RegisterClient
+		err error
+		quit bool
+		initialRegister = true
+		initialRegisterErr error
+	)
 
+	// This might not error even if the handler returns an err - need to attempt
+	// to perform a recv to verify.
 	srv, err := s.serverClient.Register(s.config.ShutdownCtx, req)
-	if err != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
+	if err != nil {
 		return errors.Wrap(err, "unable to complete initial registration with snitch server")
 	}
 
@@ -53,6 +59,8 @@ func (s *Snitch) register(looper director.Looper) error {
 			return nil
 		}
 
+		// No way to hit this case for a "first register attempt" because
+		// "stream" won't be nil on initial launch.
 		if stream == nil {
 			s.config.Logger.Debug("stream is nil, attempting to register")
 
@@ -62,6 +70,7 @@ func (s *Snitch) register(looper director.Looper) error {
 					s.config.Logger.Debug("context cancelled during connect")
 					quit = true
 					looper.Quit()
+
 					return nil
 				}
 
@@ -84,6 +93,16 @@ func (s *Snitch) register(looper director.Looper) error {
 		// Blocks until something is received
 		cmd, err := stream.Recv()
 		if err != nil {
+			// This is the first registration attempt and it has failed - we need
+			// to stop the loop and tell the caller that we failed to register.
+			if initialRegister {
+				initialRegisterErr = err
+				quit = true
+				looper.Quit()
+
+				return nil
+			}
+
 			if err.Error() == "rpc error: code = Canceled desc = context canceled" {
 				s.config.Logger.Errorf("context cancelled during recv: %s", err)
 				quit = true
@@ -107,6 +126,10 @@ func (s *Snitch) register(looper director.Looper) error {
 
 			return nil
 		}
+
+		// Initial registration has succeeded - no longer need to bail out if we
+		// encounter any errors
+		initialRegister = false
 
 		if cmd == nil {
 			s.config.Logger.Debug("Received nil command, ignoring")
@@ -177,6 +200,10 @@ func (s *Snitch) register(looper director.Looper) error {
 
 		return nil
 	})
+
+	if initialRegister {
+		return errors.Wrap(initialRegisterErr, "failed to complete initial registration with snitch-server")
+	}
 
 	return nil
 }

--- a/server/client.go
+++ b/server/client.go
@@ -61,7 +61,7 @@ func New(snitchAddress, snitchToken string) (*Client, error) {
 
 	conn, err := grpc.DialContext(dialCtx, snitchAddress, opts...)
 	if err != nil {
-		return nil, errors.Wrap(err, "Could not dial GRPC server: %s")
+		return nil, errors.Wrap(err, "could not dial GRPC server: %s")
 	}
 
 	return &Client{


### PR DESCRIPTION
@blinktag let's discuss this in the morning.

Most important part is that `New()` will now error on initial registration failure. This wasn't happening before unless the server was down - an auth error would not cause a failure because `.Register()` will only error on a transport error. This change checks the first recv - if it errors AND it's an initial registration - it will bail out and return an error.

I also exposed an `IgnoreStartupError` config flag that you can pass to "try initializing forever" (that is how it essentially worked before).

I also added some additional validation and comments/docs.

I also udpated the tests - they were actually returning a false negative before - as in, they were suceeding even though the server was not ever able to startup. This was masked by the fact that Register() never failed before so the test for New() never failed, even though it should have. To be able to perform a full gRPC server test, I needed to implement the `Register(...)` gRPC handler and have it send something to the client.

Aside from the above, I would like to discuss `SnitchURL` and `SnitchToken` once more.

EDIT: I'm going to leave some comments so that I don't forget why I did xyz 😄 