### PR TITLE
enabling keepalive

### DIFF
--- a/register.go
+++ b/register.go
@@ -73,8 +73,8 @@ func (s *Snitch) register(looper director.Looper) error {
 			return nil
 		}
 
-		// No way to hit this case for a "first register attempt" because
-		// "stream" won't be nil on initial launch.
+		// This is here to enable reconnects; no way to hit this case for a
+		// "first register attempt" because "stream" won't be nil on initial launch.
 		if stream == nil {
 			s.config.Logger.Debug("stream is nil, attempting to register")
 

--- a/server/client.go
+++ b/server/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/streamdal/snitch-protos/build/go/protos"
@@ -63,6 +64,18 @@ func New(snitchAddress, snitchToken string) (*Client, error) {
 
 	opts := make([]grpc.DialOption, 0)
 	opts = append(opts,
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			// Enable keepalive; ping every 10s
+			Time: 10 * time.Second,
+
+			// Close stream if there is still no activity after 30s.
+			//
+			// NOTE: there should ALWAYS be activity on the streams because the
+			// server sends periodic heartbeats to the client AND the client
+			// sends periodic heartbeats to the server. If stream is disconnected,
+			// client will auto re-establish connectivity with the server.
+			Timeout: 30 * time.Second,
+		}),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxGRPCMessageRecvSize)),
 		grpc.WithInsecure(),
 	)

--- a/snitch.go
+++ b/snitch.go
@@ -87,21 +87,21 @@ type ISnitch interface {
 type Snitch struct {
 	config             *Config
 	functions          map[string]*function
-	pipelines          map[string]map[string]*protos.Command
-	pipelinesPaused    map[string]map[string]*protos.Command
+	pipelines          map[string]map[string]*protos.Command // k1: audienceStr k2: pipelineID
+	pipelinesPaused    map[string]map[string]*protos.Command // k1: audienceStr k2: pipelineID
 	functionsMtx       *sync.RWMutex
 	pipelinesMtx       *sync.RWMutex
 	pipelinesPausedMtx *sync.RWMutex
 	serverClient       server.IServerClient
 	metrics            metrics.IMetrics
-	audiences          map[string]struct{}
+	audiences          map[string]struct{} // k: audienceStr
 	audiencesMtx       *sync.RWMutex
 	sessionID          string
 	kv                 kv.IKV
 	hf                 *hostfunc.HostFunc
 	tailsMtx           *sync.RWMutex
-	tails              map[string]map[string]*Tail
-	schemas            map[string]*protos.Schema
+	tails              map[string]map[string]*Tail // k1: audienceStr k2: tailID
+	schemas            map[string]*protos.Schema   // k: audienceStr
 	schemasMtx         *sync.RWMutex
 }
 


### PR DESCRIPTION
@blinktag 

Here is my thinking.

By default, clients do not have keepalives enabled and idle connections are never closed. This sounds good, but I think by enabling keepalives, we will actually gain better long-running connection reliability - as in, connections will be agressively closed if they look like they're dead. This should cause the client to reconnect and re-establish the session.

Here's also what I found from the gRPC folks:

https://grpc.io/docs/guides/keepalive/#common-situations-where-keepalives-can-be-useful

```
gRPC HTTP/2 keepalives can be useful in a variety of situations, including but not limited to:

When sending data over a long-lived connection which might be considered as idle by proxy or load balancers.
When the network is less reliable (For example, mobile applications).
When using a connection after a long period of inactivity.
```

^ That seems to fit our bill - connections might be unstable, might be going through a proxy - this will ensure that connections are aggressively recycled.

Let's give it a shot?